### PR TITLE
Fixed splitlines error in filter_caffe.py

### DIFF
--- a/src/filter_caffe/filter_caffe.py
+++ b/src/filter_caffe/filter_caffe.py
@@ -24,7 +24,7 @@ PROBABILITY_THRESHOLD = 0.5
 # [0.0115129 - n04125021 safe]
 #
 def filter_caffe_message(caffe_message):
-    lines = caffe_message.splitlines()
+    lines = str(caffe_message).splitlines()
     if (len(lines) == 0):
         return None
     first_line = lines[0]


### PR DESCRIPTION
caffe_message was a ROS String and not a python string and as a result was erroring out on the .splitlines line. Wrapping it in a python conversion to str solved the problem